### PR TITLE
Add a basic NSIS script + ant target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /jssc_2.6.0_qz/build/
 /jssc_2.6.0_qz/dist/
 /qz-print/build/
-/qz-print/dist/
+/qz-print/out/
+/qz-print/qz-print.nsi

--- a/qz-print/build.xml
+++ b/qz-print/build.xml
@@ -170,7 +170,15 @@
                 <expandproperties/>
             </filterchain>
         </copy>
-        <exec executable="makensis" failonerror="true" >
+
+        <!-- Find makensis executable -->
+        <property name="nsisexe" value="makensis"/>
+        <property name="nsiswin" value="C:\Program Files\NSIS\makensis.exe"/>
+        <property name="nsiswin64" value="C:\Program Files (x86)\NSIS\makensis.exe"/>
+        <available property="nsisexe" value="${nsiswin}" type="file" file="${nsiswin}"/>
+        <available property="nsisexe" value="${nsiswin64}" type="file" file="${nsiswin64}"/>
+
+        <exec executable="${nsisexe}" failonerror="true" >
             <arg value="${basedir}/qz-print.nsi"/>
         </exec>
     </target>

--- a/qz-print/build.xml
+++ b/qz-print/build.xml
@@ -24,6 +24,7 @@
 
     <target name="clean" depends="init">
         <delete dir="${out.dir}"/>
+        <delete file="${basedir}/qz-print.nsi"/>
     </target>
 
     <target name="compile" depends="init">
@@ -160,6 +161,18 @@
                 <filter token="VERSION" value="${build.version}"/>
             </filterset>
         </copy>
+    </target>
+
+    <target name="nsis" depends="init">
+        <echo>Creating NSIS installer</echo>
+        <copy file="${basedir}/qz-print.nsi.in" tofile="${basedir}/qz-print.nsi" >
+            <filterchain>
+                <expandproperties/>
+            </filterchain>
+        </copy>
+        <exec executable="makensis" failonerror="true" >
+            <arg value="${basedir}/qz-print.nsi"/>
+        </exec>
     </target>
 
 </project>

--- a/qz-print/qz-print.nsi.in
+++ b/qz-print/qz-print.nsi.in
@@ -1,7 +1,7 @@
 !include MUI2.nsh
 
 Name "${manifest.application.name}"
-OutFile "${out.dir}/qz-print-${build.version}-setup.exe"
+OutFile "${out.dir}/${build.name}-${build.version}-setup.exe"
 
 ;-------------------------------
 
@@ -25,9 +25,7 @@ Section
 
   SetOutPath "$INSTDIR"
 
-  File /r "${dist.applet.dir}"
-  File /r "${dist.socket.dir}"
-
+  File /r "${dist.socket.dir}/*"
 
   ;WriteRegStr HKCU "Software\qz-print" "" $INSTDIR
   WriteUninstaller "$INSTDIR\Uninstall.exe"

--- a/qz-print/qz-print.nsi.in
+++ b/qz-print/qz-print.nsi.in
@@ -1,0 +1,50 @@
+!include MUI2.nsh
+
+Name "${manifest.application.name}"
+OutFile "${out.dir}/qz-print-${build.version}-setup.exe"
+
+;-------------------------------
+
+InstallDir "$PROGRAMFILES\QZ"
+
+;-------------------------------
+
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "${basedir}/../LICENSE.txt"
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+!insertmacro MUI_LANGUAGE "English"
+
+;------------------------------
+
+Section
+
+  SetOutPath "$INSTDIR"
+
+  File /r "${dist.applet.dir}"
+  File /r "${dist.socket.dir}"
+
+
+  ;WriteRegStr HKCU "Software\qz-print" "" $INSTDIR
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+
+SectionEnd
+
+;-------------------------------
+
+Section "Uninstall"
+
+  RMDir /r "$INSTDIR\socket"
+  RMDir /r "$INSTDIR\applet"
+  Delete "$INSTDIR\readme.txt"
+
+  Delete "$INSTDIR\Uninstall.exe"
+  RMDir "$INSTDIR"
+
+  ;DeleteRegKey /ifempty HKCU "Software\qz-print"
+
+SectionEnd


### PR DESCRIPTION
Commit 30246ec adds a basic NSIS script and an according ant target. The NSIS script `qz-print.nsi.in` is pre-processed by ant using the `ExpandProperties` filter which replaces all `${property}`-like occurrences with the property's value.

![screenshot_2015-02-27_18-18-11](https://cloud.githubusercontent.com/assets/2879917/6417331/057fd65c-bead-11e4-8c1d-3ae0e517e8e9.png)
