### PR TITLE
Fix for erroneous tray popup menu behavior on Fedora 22

### DIFF
--- a/src/qz/ws/PrintWebSocketServer.java
+++ b/src/qz/ws/PrintWebSocketServer.java
@@ -24,7 +24,7 @@ import org.eclipse.jetty.websocket.server.WebSocketHandler;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 import qz.common.TrayManager;
 import qz.deploy.DeployUtilities;
-
+import javax.swing.*;
 import java.net.BindException;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -44,7 +44,7 @@ public class PrintWebSocketServer {
     private static final Integer[] ports = new Integer[]{8181, 8282, 8383, 8484};
 
     private static final TrayManager trayManager = new TrayManager();
-
+ 
     public static void main(String[] args) {
         runServer();
     }


### PR DESCRIPTION
Fix for erroneous tray popup menu behavior on Fedora 22. The icon placment issue is still unfixed, cause by Red Hat Bug 1014448.
