### PR TITLE
Travis packaging testing, OSX build testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
+matrix:
+  include:
+    - jdk: oraclejdk8 
+      env: TARGET=nsis
+    - jdk: oraclejdk8
+      env: TARGET=makeself
+    - jdk: oraclejdk7
+      env: TARGET=makeself
+    - jdk: openjdk7
+      env: TARGET=makeself
+    - os: osx
+      env: TARGET=pkgbuild
 language: java
-script: ant
-jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk7
+before_script: 
+    - sw_vers -productVersion && brew update && brew install ant; ant -version
+    - test -e /etc/lsb-release && sudo apt-get install -y makeself nsis; echo;
+script: ant $TARGET


### PR DESCRIPTION
Adds better travis build/packaging testing via ant targets.  Also adds support for compiling on OSX.

``` yml
matrix:
  include:
    - jdk: oraclejdk8 
      env: TARGET=nsis
    - jdk: oraclejdk8
      env: TARGET=makeself
    - jdk: oraclejdk7
      env: TARGET=makeself
    - jdk: openjdk7
      env: TARGET=makeself
    - os: osx
      env: TARGET=pkgbuild
language: java
before_script: 
    - sw_vers -productVersion && brew update && brew install ant; ant -version
    - test -e /etc/lsb-release && sudo apt-get install -y makeself nsis; echo;
script: ant $TARGET
```
